### PR TITLE
CELERY_IGNORE_RESULT capability

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,19 @@
+package gocelery
+
+// Option sets up a Config.
+type Option func(*Config)
+
+// WithIgnoreResult disables a task result storage.
+// By default results are stored in the backend.
+func WithIgnoreResult() Option {
+	return func(c *Config) {
+		c.ignoreResult = true
+	}
+}
+
+// Config represents Celery client configuration.
+type Config struct {
+	// ignoreResult if set to false (default) the result of a task will be stored in the backend.
+	// If set to true the result won't be stored.
+	ignoreResult bool
+}

--- a/gocelery.go
+++ b/gocelery.go
@@ -30,11 +30,15 @@ type CeleryBackend interface {
 }
 
 // NewCeleryClient creates new celery client
-func NewCeleryClient(broker CeleryBroker, backend CeleryBackend, numWorkers int) (*CeleryClient, error) {
+func NewCeleryClient(broker CeleryBroker, backend CeleryBackend, numWorkers int, options ...Option) (*CeleryClient, error) {
+	c := Config{}
+	for _, opt := range options {
+		opt(&c)
+	}
 	return &CeleryClient{
 		broker,
 		backend,
-		NewCeleryWorker(broker, backend, numWorkers),
+		NewCeleryWorker(broker, backend, numWorkers, &c),
 	}, nil
 }
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -41,7 +41,7 @@ func TestWorkerRegisterTask(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		celeryWorker := NewCeleryWorker(tc.broker, tc.backend, 1)
+		celeryWorker := NewCeleryWorker(tc.broker, tc.backend, 1, nil)
 		taskName := uuid.Must(uuid.NewV4()).String()
 		celeryWorker.Register(taskName, tc.registeredTask)
 		receivedTask := celeryWorker.GetTask(taskName)
@@ -76,7 +76,7 @@ func TestWorkerRunTask(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		celeryWorker := NewCeleryWorker(tc.broker, tc.backend, 1)
+		celeryWorker := NewCeleryWorker(tc.broker, tc.backend, 1, nil)
 		taskName := uuid.Must(uuid.NewV4()).String()
 		celeryWorker.Register(taskName, tc.registeredTask)
 		args := []interface{}{
@@ -124,7 +124,7 @@ func TestWorkerRunTaskError(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			celeryWorker := NewCeleryWorker(tc.broker, tc.backend, 1)
+			celeryWorker := NewCeleryWorker(tc.broker, tc.backend, 1, nil)
 			taskName := uuid.Must(uuid.NewV4()).String()
 			celeryWorker.Register(taskName, tc.registeredTask)
 
@@ -174,7 +174,7 @@ func TestWorkerExpiredTask(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		celeryWorker := NewCeleryWorker(tc.broker, tc.backend, 1)
+		celeryWorker := NewCeleryWorker(tc.broker, tc.backend, 1, nil)
 		taskName := uuid.Must(uuid.NewV4()).String()
 		celeryWorker.Register(taskName, tc.registeredTask)
 		args := []interface{}{
@@ -216,7 +216,7 @@ func TestWorkerNumWorkers(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		numWorkers := rand.Intn(10)
-		celeryWorker := NewCeleryWorker(tc.broker, tc.backend, numWorkers)
+		celeryWorker := NewCeleryWorker(tc.broker, tc.backend, numWorkers, nil)
 		celeryNumWorkers := celeryWorker.GetNumWorkers()
 		if numWorkers != celeryNumWorkers {
 			t.Errorf("test '%s': number of workers are different: %d vs %d", tc.name, numWorkers, celeryNumWorkers)
@@ -245,7 +245,7 @@ func TestWorkerStartStop(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		celeryWorker := NewCeleryWorker(tc.broker, tc.backend, 1000)
+		celeryWorker := NewCeleryWorker(tc.broker, tc.backend, 1000, nil)
 		go celeryWorker.StartWorker()
 		time.Sleep(100 * time.Millisecond)
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)


### PR DESCRIPTION
Add ability to control whether to store the task return values or not (tombstones), see `CELERY_IGNORE_RESULT` at https://docs.celeryproject.org/en/stable/userguide/configuration.html.